### PR TITLE
Make things a little more Rusty.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/awesome-blog.iml
+++ b/.idea/awesome-blog.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/awesome-blog.iml" filepath="$PROJECT_DIR$/.idea/awesome-blog.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/posts/the-second-post/post.md
+++ b/posts/the-second-post/post.md
@@ -1,0 +1,12 @@
+# The Second Article
+
+Hi there, this is a test post showcasing some Markdown text.
+
+Here is some *fancy text* and some _**fancier**_ text!
+
+And a nice link to [GitHub](https://www.github.com/)!
+
+And some nice bullet points:
+* Statement 1
+* Object 2
+* Color 3

--- a/posts/the-second-post/post_frontmatter.toml
+++ b/posts/the-second-post/post_frontmatter.toml
@@ -1,0 +1,8 @@
+title = 'The Second Post'
+file_name = 'the-second-post'
+description = 'A stranger is a friend you have not met yet.'
+tags = ['']
+posted = '24/08/2023'
+estimated_reading_time = 2
+author = 'Adam'
+order = 2

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub static CONTENT_TYPE_TEXT_HTML: &str = "text/html";

--- a/src/handlers/home_handler.rs
+++ b/src/handlers/home_handler.rs
@@ -1,54 +1,34 @@
 use actix_web::{get, web, HttpResponse, Responder};
 use ignore::WalkBuilder;
-use serde::{Deserialize, Serialize};
 use std::{fs, io::Error};
+use crate::constants::CONTENT_TYPE_TEXT_HTML;
+use crate::models::frontmatter::Frontmatter;
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Frontmatter {
-    title: String,
-    file_name: String,
-    description: String,
-    posted: String,
-    tags: Vec<String>,
-    author: String,
-    estimated_reading_time: u32,
-    order: u32,
-}
 
-fn find_all_frontmatters() -> Result<Vec<Frontmatter>, std::io::Error> {
-    let mut t = ignore::types::TypesBuilder::new();
-    t.add_defaults();
-    let toml = match t.select("toml").build() {
-        Ok(t) => t,
-        Err(e) => {
-            println!("{:}", e);
-            return Err(Error::new(
-                std::io::ErrorKind::Other,
-                "could not build toml file type matcher",
-            ));
-        }
-    };
+fn get_all_file_contents_in_folder(folder: &str, file_type: &str) -> Result<Vec<Frontmatter>, Error> {
+    let mut type_builder = ignore::types::TypesBuilder::new();
+    type_builder.add_defaults();
+    let file_type_matcher = type_builder.select(&file_type).build()
+        .map_err(|err| {
+            Error::new(std::io::ErrorKind::Other, format!("Could not build {} file type matcher. Error: {:?}", &file_type, err))
+        })?;
 
-    let file_walker = WalkBuilder::new("./posts").types(toml).build();
+    let post_folder_toml_files = WalkBuilder::new(folder).types(file_type_matcher).build();
 
     let mut frontmatters = Vec::new();
-    for frontmatter in file_walker {
-        match frontmatter {
-            Ok(fm) => {
-                if fm.path().is_file() {
-                    let fm_content = fs::read_to_string(fm.path())?;
-                    let frontmatter: Frontmatter = toml::from_str(&fm_content)?;
+    for toml_file in post_folder_toml_files {
+        let toml_file = toml_file.map_err(|err|{
+            Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Could not locate file with format {}. Error: {:?}", &file_type, err),
+            )
+        })?;
 
-                    frontmatters.push(frontmatter);
-                }
-            }
-            Err(e) => {
-                println!("{:}", e); // we're just going to print the error for now
-                return Err(Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "could not locate frontmatter",
-                ));
-            }
+        if toml_file.path().is_file() {
+            let fm_content = fs::read_to_string(toml_file.path())?;
+            let frontmatter: Frontmatter = toml::from_str(&fm_content)?;
+
+            frontmatters.push(frontmatter);
         }
     }
 
@@ -57,28 +37,17 @@ fn find_all_frontmatters() -> Result<Vec<Frontmatter>, std::io::Error> {
 
 #[get("/")]
 pub async fn index(templates: web::Data<tera::Tera>) -> impl Responder {
-    let mut context = tera::Context::new();
 
-    let mut frontmatters = match find_all_frontmatters() {
-        Ok(fm) => fm,
-        Err(e) => {
-            println!("{:?}", e);
-            return HttpResponse::InternalServerError()
-                .content_type("text/html")
-                .body("<p>Something went wrong!</p>");
-        }
-    };
-    frontmatters.sort_by(|a, b| b.order.cmp(&a.order));
+    if let Ok(mut frontmatters) = get_all_file_contents_in_folder("./posts", "toml") {
+        let mut context = tera::Context::new();
+        frontmatters.sort_by_key(|p| std::cmp::Reverse(p.order()));
+        context.insert("posts", &frontmatters);
 
-    context.insert("posts", &frontmatters);
-
-    match templates.render("home.html", &context) {
-        Ok(s) => HttpResponse::Ok().content_type("text/html").body(s),
-        Err(e) => {
-            println!("{:?}", e);
-            HttpResponse::InternalServerError()
-                .content_type("text/html")
-                .body("<p>Something went wrong!</p>")
+        if let Ok(template_render) = templates.render("home.html", &context) {
+            return HttpResponse::Ok().content_type(CONTENT_TYPE_TEXT_HTML).body(template_render);
         }
     }
+    return HttpResponse::InternalServerError()
+        .content_type(CONTENT_TYPE_TEXT_HTML)
+        .body("<p>Something went wrong!</p>");
 }

--- a/src/handlers/post_handler.rs
+++ b/src/handlers/post_handler.rs
@@ -2,39 +2,21 @@ use std::{io::Error, fs};
 
 use actix_web::{web, get, Responder, HttpResponse};
 use pulldown_cmark::{Options, Parser, html};
+use crate::constants::CONTENT_TYPE_TEXT_HTML;
+use crate::models::frontmatter::Frontmatter;
 
-use super::home_handler::Frontmatter;
 
 fn extract_markdown(post_name: &str) -> Result<String, Error> {
-	let markdown = match fs::read_to_string(format!("./posts/{}/post.md", post_name)) {
-		Ok(markdown) => markdown,
-		Err(e) => {
-			println!("{:?}", e);
-			return Err(e)
-		}
-	};
-
-    Ok(markdown)
+	fs::read_to_string(format!("./posts/{}/post.md", post_name))
 }
 
 fn extract_frontmatter(post_name: &str) -> Result<Frontmatter, Error> {
-	let frontmatter_input =	match fs::read_to_string(format!("./posts/{}/post_frontmatter.toml", post_name)) {
-		Ok(s) => s,
-		Err(e) => {
-			println!("{:?}", e);
-			return Err(e)
-		}
-	};
-	
-	let frontmatter = match toml::from_str(&frontmatter_input) {
-		Ok(fm) => fm,
-		Err(e) => {
-			println!("{:?}", e);
-			return Err(Error::new(std::io::ErrorKind::Other, "could not find post frontmatter"))
-		}
-	};
+	let frontmatter_input = fs::read_to_string(format!("./posts/{}/post_frontmatter.toml", post_name))?;
 
-    Ok(frontmatter)
+	toml::from_str(&frontmatter_input)
+		.map_err(|_err| {
+			Error::new(std::io::ErrorKind::Other, "Not a valid TOML file.")
+		})
 }
 
 #[get("/posts/{post_name}")]
@@ -42,44 +24,20 @@ pub async fn post(
 	tmpl: web::Data<tera::Tera>,
 	post_name: web::Path<String>,
 ) -> impl Responder {
-	let mut context = tera::Context::new();
-	let options = Options::empty(); // used as part of pulldown_cmark for setting flags to enable extra features - we're not going to use any of those, hence the `empty();`
+	if let (Ok(markdown_input), Ok(frontmatter)) = (extract_markdown(&post_name), extract_frontmatter(&post_name)) {
+		let mut html_output = String::new();
+		let parser = Parser::new_ext(&markdown_input, Options::empty());
+		html::push_html(&mut html_output, parser);
 
-	let markdown_input = match extract_markdown(&post_name) {
-		Ok(s) => s,
-		Err(e) => {
-			println!("{:?}", e);
-			return HttpResponse::NotFound()
-				.content_type("text/html")
-				.body("<p>Could not find post - sorry!</p>")
-		}
-	};
-	
-	let frontmatter = match extract_frontmatter(&post_name) {
-		Ok(s) => s,
-		Err(e) => {
-			println!("{:?}", e);
-			return HttpResponse::NotFound()
-				.content_type("text/html")
-				.body("<p>Could not find post - sorry!</p>")
-		}
-	};
-	
-	let parser = Parser::new_ext(&markdown_input, options);
-	
-	let mut html_output = String::new();
-	html::push_html(&mut html_output, parser);
-	
-	context.insert("post", &html_output);
-	context.insert("meta_data", &frontmatter);
-	
-	match tmpl.render("post.html", &context) {
-		Ok(s) => HttpResponse::Ok().content_type("text/html").body(s),	
-		Err(e) => {
-			println!("{:?}", e);
-			return HttpResponse::NotFound()
-				.content_type("text/html")
-				.body("<p>Could not find post - sorry!</p>")
+		let mut context = tera::Context::new();
+		context.insert("post", &html_output);
+		context.insert("meta_data", &frontmatter);
+
+		if let Ok(tmpl_render) = tmpl.render("post.html", &context) {
+			return HttpResponse::Ok().content_type(CONTENT_TYPE_TEXT_HTML).body(tmpl_render);
 		}
 	}
+	HttpResponse::NotFound()
+		.content_type(CONTENT_TYPE_TEXT_HTML)
+		.body("<p>Could not find post - sorry!</p>")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,19 @@
+pub mod constants;
+pub mod handlers;
+pub mod models;
+
 use actix_files::Files;
 use actix_web::{dev::Server, middleware, web, App, HttpResponse, HttpServer};
 use std::net::TcpListener;
 use tera::Tera;
 
-pub mod handlers;
 
 #[macro_use]
 extern crate lazy_static;
 
 lazy_static! {
     pub static ref TEMPLATES: Tera = {
-        let mut tera = match Tera::new("templates/**/*.html") {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Parsing error(s): {}", e);
-                ::std::process::exit(1);
-            }
-        };
+        let mut tera = Tera::new("templates/**/*.html").expect("Unable to unwrap Tera template.");
         tera.autoescape_on(vec![".html", ".sql"]);
         tera
     };
@@ -29,7 +26,7 @@ pub fn start_blog(listener: TcpListener) -> Result<Server, std::io::Error> {
             .wrap(middleware::Logger::default())
             .service(Files::new("/static", "static/").use_last_modified(true))
             .route("/health", web::get().to(HttpResponse::Ok))
-            .service(handlers::index) 
+            .service(handlers::index)
             .service(handlers::post)
     })
     .listen(listener)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,8 @@ use awesome_blog::start_blog;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
     let listener = TcpListener::bind("0.0.0.0:8080")?;
-    start_blog(listener)?.await?;
-
-    Ok(())
+    start_blog(listener)?.await
 }

--- a/src/models/frontmatter.rs
+++ b/src/models/frontmatter.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Frontmatter {
+    title: String,
+    file_name: String,
+    description: String,
+    posted: String,
+    tags: Vec<String>,
+    author: String,
+    estimated_reading_time: u32,
+    order: u32,
+}
+impl Frontmatter {
+    pub fn order(&self) -> u32 {
+        self.order
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod frontmatter;


### PR DESCRIPTION
I cleaned up the logic to make it a bit simpler. Instead of using duplicate Errors, just use `if let` and fall back to that error.

Created a directory for constant values, so we don't have to worry about typos.

Abstracted out a few functions in case they're needed for other file types, folders, etc.

Used built in `sort_by_key`.

Used `map_err` and `map_err(..)?` in places where it was logical, instead of match when we don't change the Ok value.

